### PR TITLE
fix: ensure renderListContent does not fail when given empty arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export default class SectionsCard extends React.Component {
     }
     return {};
   }
-  renderListContent(linkList) {
+  renderListContent(linkList = []) {
     return linkList.map((link, i) => {
       const commonProps = {
         key: `${ i }`,


### PR DESCRIPTION
This adds some extra defensibility within upstream code paths, which can sometimes omit
the secions data for the `data` prop.