### PR TITLE
fix: WP-89 - allow optional other type of SectionCardList

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,17 @@ import SectionCardList from './parts/section-card-list';
 
 export default function SectionsCard({ data, titles }) { // eslint-disable-line id-blacklist
   const links = data; // eslint-disable-line id-blacklist
+  const sectionsSection = <SectionCardList topic="sections" links={links.sections} title={titles.sections} />;
   return (
     <nav role="nav" className="sections-card">
       <div className="sections-card__wrapper">
         <div className="sections-card__menu">
-          <SectionCardList topic="sections" links={links.sections} title={titles.sections} />
+          {typeof links.other === 'undefined' ? sectionsSection :
+              <div className="sections-card__list-column-wrap">
+                {sectionsSection}
+                <SectionCardList topic="other" links={links.other} title={titles.other} />
+              </div>
+          }
           <SectionCardList topic="media" links={links.media} title={titles.media} />
           <SectionCardList topic="blogs" links={links.blogs} title={titles.blogs} />
         </div>


### PR DESCRIPTION
This is a fix for the component-sections-card regarding the task WP-89 https://jira.economist.com/browse/WP-89 . It needs to be accompanied by changes in fe-blogs.