### PR TITLE
fix: WP-1541 - allow to group elements into columns

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 import List from './parts/section-card-list.js';
 import Main from './parts/section-card-wrapper.js';
+import Link from './parts/section-card-link.js';
 
 const SectionsCard = {
   Main,
   List,
+  Link,
 };
 export default SectionsCard;

--- a/src/parts/section-card-link.js
+++ b/src/parts/section-card-link.js
@@ -1,10 +1,13 @@
 import Button from '@economist/component-link-button';
 import React from 'react';
 
-export default function SectionCardLink({ buttonClassName, title, buttonProps, prefix }) {
+export default function SectionCardLink({ buttonClassName, linkClassName, title, buttonProps, prefix }) {
   const { internal, ...cleanedButtonProps } = buttonProps; // eslint-disable-line no-unused-vars
+  const customLinkClassName = linkClassName ?
+  `${ prefix }__list-item ${ prefix }__list-item--${ linkClassName }` :
+  `${ prefix }__list-item`;
   return (
-    <li className={`${ prefix }__list-item`}>
+    <li className={customLinkClassName}>
       <Button
         {...cleanedButtonProps}
         className={buttonClassName}
@@ -18,6 +21,7 @@ export default function SectionCardLink({ buttonClassName, title, buttonProps, p
 if (process.env.NODE_ENV !== 'production') {
   SectionCardLink.propTypes = {
     buttonClassName: React.PropTypes.string,
+    linkClassName: React.PropTypes.string,
     buttonProps: React.PropTypes.shape({
       target: React.PropTypes.string,
       unstyled: React.PropTypes.bool,

--- a/src/parts/section-card-wrapper.js
+++ b/src/parts/section-card-wrapper.js
@@ -1,38 +1,40 @@
 import React from 'react';
-import List from './section-card-list.js';
 
 export default function SectionsCardWrapper(props) {
-  let content = [];
-  let joinContent = [];
+  const content = [];
   const { children, className } = props;
   const prefix = className ? `${ className }` : 'sections-card';
   React.Children.forEach(children, (child, key) => {
-    if (child.type === List) {
-      const contentSwitch =
-        (<List
-          key={key}
-          topic={child.props.topic}
-          links={child.props.links}
-          title={child.props.title}
-          prefix={prefix}
-         />);
-      if (child.props.wrapColumns) {
-        joinContent.push(contentSwitch);
-      } else {
-        content.push(contentSwitch);
-      }
+    const orderProp = child.props.order;
+    const childOrder = isNaN(orderProp) ? key : orderProp;
+    const renderedChild = (
+      <child.type
+        key={key}
+        prefix={prefix}
+        {...child.props}
+      />
+    );
+    if (content[childOrder]) {
+      content[childOrder] = content[childOrder].concat([ renderedChild ]);
+    } else {
+      content[childOrder] = [ renderedChild ];
     }
+  });
+  const renderableContent = content.map((arrayGroup) => {
+    if (arrayGroup.length > 1) {
+      return (
+        <div className={`${ prefix }__list ${ prefix }__list-wrapper--column-wrap`}>
+          {arrayGroup}
+        </div>
+      );
+    }
+    return arrayGroup[0];
   });
   return (
     <nav role="nav" className={`${ prefix }`}>
       <div className={`${ prefix }__wrapper`}>
         <div className={`${ prefix }__menu`}>
-          {joinContent[0] ?
-            <div className={`${ prefix }__list ${ prefix }__list-wrapper--column-wrap`}>
-              {joinContent}
-            </div> :
-          null}
-          {content}
+          {renderableContent}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
This PR was created for https://jira.economist.com/browse/DISCO-39.

It lets the developers use the `SectionsCard.Link` component also as an individual element of the `SectionsCard` wrapper. It also lets to order the components, and group certain elements into columns. Until now the logic was hardcoded with the help of the prop `wrapColumns`, but it only wrapped elements into the first position of the horizontal flex wrapper.